### PR TITLE
remove logout when passwordless

### DIFF
--- a/lib/Utils/Session.php
+++ b/lib/Utils/Session.php
@@ -33,6 +33,10 @@ class Session
 		return self::$_instance;
 	}
 
+	public static function is_passwordless(){
+		return ! Config::Get('security') ;
+	}
+
 	public function login($password)
 	{
 		if(Config::Get('password') === md5($password))

--- a/lib/Views/Header.php
+++ b/lib/Views/Header.php
@@ -70,8 +70,11 @@ abstract class Header
 						</ul>
 					</li>
 				</ul>
-				<ul class="nav navbar-nav navbar-right">
-					<li><a href="./logout.php">Logout</a></li>
+				<ul class="nav navbar-nav navbar-right">';
+			if(! Session::is_passwordless()) 
+				echo '<li><a href="./logout.php">Logout</a></li>';  
+                        
+			echo '
 				</ul>
 			</div>';
 		}

--- a/login.php
+++ b/login.php
@@ -3,6 +3,11 @@
 namespace MediaDownloader;
 require_once 'init.php';
 
+if (Utils\Session::is_passwordless()){
+        header("Location: index.php");
+        exit(0);
+}
+
 $loginFailed = false;
 
 if(isset($_POST["password"]))


### PR DESCRIPTION
This patch will remove the Logout icon on the header of view and also bypass the login screen if it was requested (due to bookmarked or what ever).
